### PR TITLE
refuse duplicated cluster name, rebuild router if a reconnection happens

### DIFF
--- a/cmd/clustercontroller/app/app.go
+++ b/cmd/clustercontroller/app/app.go
@@ -97,14 +97,15 @@ func Run() error {
 	clusterToEdgeChan := make(chan otev1.ClusterController)
 	// make config for cluster controller.
 	clusterConfig := &config.ClusterControllerConfig{
-		TunnelListenAddr:  tunnelListenAddr,
-		ParentCluster:     parentCluster,
-		ClusterName:       clusterName,
-		K8sClient:         k8sClient,
-		HelmTillerAddr:    helmTillerAddr,
-		RemoteShimAddr:    remoteShimAddr,
-		EdgeToClusterChan: edgeToClusterChan,
-		ClusterToEdgeChan: clusterToEdgeChan,
+		TunnelListenAddr:      tunnelListenAddr,
+		ParentCluster:         parentCluster,
+		ClusterName:           clusterName,
+		ClusterUserDefineName: clusterName,
+		K8sClient:             k8sClient,
+		HelmTillerAddr:        helmTillerAddr,
+		RemoteShimAddr:        remoteShimAddr,
+		EdgeToClusterChan:     edgeToClusterChan,
+		ClusterToEdgeChan:     clusterToEdgeChan,
 	}
 
 	// start edge/cluster handler.

--- a/pkg/apis/ote/v1/types.go
+++ b/pkg/apis/ote/v1/types.go
@@ -37,6 +37,7 @@ const (
 	CLUSTER_CONTROLLER_DEST_REGIST_CLUSTER   = "regist"   // cluster regist
 	CLUSTER_CONTROLLER_DEST_UNREGIST_CLUSTER = "unregist" // cluster unregist
 	CLUSTER_CONTROLLER_DEST_CLUSTER_ROUTE    = "route"    // cluster route
+	CLUSTER_CONTROLLER_DEST_CLUSTER_SUBTREE  = "subtree"  // cluster subtree
 )
 
 // CLUSTER_NAMESPACE defines the namespace of k8s crd must be in.
@@ -95,8 +96,9 @@ type Cluster struct {
 }
 
 type ClusterSpec struct {
-	Name   string `json:"name"`
-	Listen string `json:"listen"`
+	Name       string `json:"name"`
+	Listen     string `json:"listen"`
+	ParentName string `json:"parentName"`
 	// Childs describes the relation of cluster name to its websocket listen address.
 	Childs map[string]string `json:"childs"`
 }

--- a/pkg/clusterhandler/clusterhandler_test.go
+++ b/pkg/clusterhandler/clusterhandler_test.go
@@ -42,11 +42,11 @@ func TestInit(t *testing.T) {
 		conf:      c,
 		k8sEnable: false,
 	}
-	h.conf.ClusterName = ""
+	h.conf.ClusterUserDefineName = ""
 	assert.Error(t, h.valid())
 
 	// test root cluster config
-	h.conf.ClusterName = config.ROOT_CLUSTER_NAME
+	h.conf.ClusterUserDefineName = config.ROOT_CLUSTER_NAME
 	assert.Error(t, h.valid())
 	h.conf.TunnelListenAddr = ":8272"
 	assert.Error(t, h.valid())
@@ -58,7 +58,7 @@ func TestInit(t *testing.T) {
 	assert.Error(t, h.valid())
 
 	// test no-root cluster config
-	h.conf.ClusterName = "c1"
+	h.conf.ClusterUserDefineName = "c1"
 	h.conf.ParentCluster = ""
 	assert.Error(t, h.valid())
 	h.conf.ParentCluster = "parent"
@@ -150,11 +150,11 @@ func TestStart(t *testing.T) {
 	fakeTunn.reset()
 	c := &clusterHandler{
 		conf: &config.ClusterControllerConfig{
-			TunnelListenAddr:  "fake",
-			K8sClient:         fakeK8sClient,
-			EdgeToClusterChan: make(chan otev1.ClusterController),
-			ClusterToEdgeChan: make(chan otev1.ClusterController),
-			ClusterName:       config.ROOT_CLUSTER_NAME,
+			TunnelListenAddr:      "fake",
+			K8sClient:             fakeK8sClient,
+			EdgeToClusterChan:     make(chan otev1.ClusterController),
+			ClusterToEdgeChan:     make(chan otev1.ClusterController),
+			ClusterUserDefineName: config.ROOT_CLUSTER_NAME,
 		},
 		tunn:      fakeTunn,
 		k8sEnable: false,
@@ -216,14 +216,14 @@ func TestHandleMessageFromChild(t *testing.T) {
 	err = c.handleMessageFromChild("c1", ccbytes)
 	assert.NotNil(t, err)
 	// resp from child with no namespace and name
-	cc.Spec.ParentClusterName = c.conf.ClusterName
+	cc.Spec.ParentClusterName = c.conf.ClusterUserDefineName
 	cc.Spec.Destination = otev1.CLUSTER_CONTROLLER_DEST_API
 	ccbytes, err = cc.Serialize()
 	assert.Nil(t, err)
 	err = c.handleMessageFromChild("c1", ccbytes)
 	assert.Nil(t, err)
 	// resp from child transmit to parent
-	cc.Spec.ParentClusterName = c.conf.ClusterName + "1"
+	cc.Spec.ParentClusterName = c.conf.ClusterUserDefineName + "1"
 	ccbytes, err = cc.Serialize()
 	assert.Nil(t, err)
 	err = c.handleMessageFromChild("c1", ccbytes)
@@ -281,9 +281,9 @@ func (f *fakeCloudTunnel) RegistClientCloseHandler(fn tunnel.ClientCloseHandleFu
 func newFakeRootClusterHandler(t *testing.T) *clusterHandler {
 	ret := &clusterHandler{
 		conf: &config.ClusterControllerConfig{
-			ClusterName:      config.ROOT_CLUSTER_NAME,
-			TunnelListenAddr: "8272",
-			K8sClient:        oteclient.NewSimpleClientset(),
+			ClusterUserDefineName: config.ROOT_CLUSTER_NAME,
+			TunnelListenAddr:      "8272",
+			K8sClient:             oteclient.NewSimpleClientset(),
 		},
 		tunn:      fakeTunn,
 		k8sEnable: false,
@@ -297,10 +297,10 @@ func newFakeRootClusterHandler(t *testing.T) *clusterHandler {
 func newFakeNoRootClusterHandler(t *testing.T) *clusterHandler {
 	ret := &clusterHandler{
 		conf: &config.ClusterControllerConfig{
-			ClusterName:      "c1",
-			TunnelListenAddr: "8273",
-			K8sClient:        oteclient.NewSimpleClientset(),
-			ParentCluster:    "8272",
+			ClusterUserDefineName: "c1",
+			TunnelListenAddr:      "8273",
+			K8sClient:             oteclient.NewSimpleClientset(),
+			ParentCluster:         "8272",
 		},
 		tunn:      fakeTunn,
 		k8sEnable: false,

--- a/pkg/edgehandler/edgehandler_test.go
+++ b/pkg/edgehandler/edgehandler_test.go
@@ -50,6 +50,10 @@ func (f *fakeEdgeTunnel) RegistReceiveMessageHandler(tunnel.TunnelReadMessageFun
 	return
 }
 
+func (f *fakeEdgeTunnel) RegistAfterConnectToHook(tunnel.AfterConnectToHook) {
+	return
+}
+
 func (f *fakeEdgeTunnel) Start() error {
 	return nil
 }
@@ -83,19 +87,21 @@ func TestValid(t *testing.T) {
 		{
 			Name: "edgehandler with k8sclient",
 			Conf: &config.ClusterControllerConfig{
-				ClusterName:    "child",
-				K8sClient:      &oteclient.Clientset{},
-				RemoteShimAddr: "",
-				ParentCluster:  "127.0.0.1:8287",
+				ClusterName:           "child",
+				ClusterUserDefineName: "child",
+				K8sClient:             &oteclient.Clientset{},
+				RemoteShimAddr:        "",
+				ParentCluster:         "127.0.0.1:8287",
 			},
 		},
 		{
 			Name: "edgehandler with remoteshim",
 			Conf: &config.ClusterControllerConfig{
-				ClusterName:    "child",
-				K8sClient:      nil,
-				RemoteShimAddr: "/var/run/shim.sock",
-				ParentCluster:  "127.0.0.1:8287",
+				ClusterName:           "child",
+				ClusterUserDefineName: "child",
+				K8sClient:             nil,
+				RemoteShimAddr:        "/var/run/shim.sock",
+				ParentCluster:         "127.0.0.1:8287",
 			},
 		},
 	}

--- a/pkg/k8sclient/cluster.go
+++ b/pkg/k8sclient/cluster.go
@@ -60,3 +60,10 @@ func (c *ClusterCRD) Delete(cluster *otev1.Cluster) {
 		klog.Errorf("delete cluster(%v) failed: %v", cluster, err)
 	}
 }
+
+func (c *ClusterCRD) Update(cluster *otev1.Cluster) {
+	_, err := c.client.OteV1().Clusters(cluster.ObjectMeta.Namespace).Update(cluster)
+	if err != nil {
+		klog.Errorf("update cluster(%v) failed: %v", cluster, err)
+	}
+}

--- a/pkg/tunnel/edgetunnel.go
+++ b/pkg/tunnel/edgetunnel.go
@@ -45,36 +45,44 @@ type EdgeTunnel interface {
 	Send(msg []byte) error
 	// Regist registers receive message handler.
 	RegistReceiveMessageHandler(TunnelReadMessageFunc)
+	RegistAfterConnectToHook(fn AfterConnectToHook)
 }
 
 // edgeTunnel is responsible for communication with cloudTunnel.
 type edgeTunnel struct {
+	conf       *config.ClusterControllerConfig
 	cloudAddr  string
 	name       string
+	uuid       string
 	listenAddr string
 	wsclient   *WSClient
 
 	receiveMessageHandler TunnelReadMessageFunc
+	afterConnectToHook    AfterConnectToHook
 }
 
 // NewEdgeTunnel returns a new edgeTunnel object.
 func NewEdgeTunnel(conf *config.ClusterControllerConfig) EdgeTunnel {
 	return &edgeTunnel{
-		name:       conf.ClusterName,
+		conf:       conf,
+		name:       conf.ClusterUserDefineName,
 		cloudAddr:  conf.ParentCluster,
 		listenAddr: conf.TunnelListenAddr,
 		receiveMessageHandler: func(client string, msg []byte) error {
 			fmt.Println(string(msg))
 			return nil
 		},
+		afterConnectToHook: func() {},
 	}
 
 }
 
 func (e *edgeTunnel) connect() error {
-	u := url.URL{Scheme: "ws", Host: e.cloudAddr, Path: accessURI + e.name}
+	e.uuid = fmt.Sprintf("%s-%d", e.name, time.Now().Unix())
+	u := url.URL{Scheme: "ws", Host: e.cloudAddr, Path: accessURI + e.uuid}
 	header := http.Header{}
 	header.Add(config.CLUSTER_CONNECT_HEADER_LISTEN_ADDR, e.listenAddr)
+	header.Add(config.CLUSTER_CONNECT_HEADER_USER_DEFINE_NAME, e.name)
 
 	klog.Infof("connecting to cloudtunnel %s", u.String())
 	// TODO https connection.
@@ -86,8 +94,13 @@ func (e *edgeTunnel) connect() error {
 		return err
 	}
 
+	e.conf.ClusterName = e.uuid
+
 	// TODO gradeful new wsclient.
-	e.wsclient = NewWSClient(e.name, conn)
+	e.wsclient = NewWSClient(e.uuid, conn)
+
+	go e.afterConnectToHook()
+
 	return nil
 }
 
@@ -105,6 +118,10 @@ func (e *edgeTunnel) Send(msg []byte) error {
 
 func (e *edgeTunnel) RegistReceiveMessageHandler(fn TunnelReadMessageFunc) {
 	e.receiveMessageHandler = fn
+}
+
+func (e *edgeTunnel) RegistAfterConnectToHook(fn AfterConnectToHook) {
+	e.afterConnectToHook = fn
 }
 
 func (e *edgeTunnel) Stop() error {

--- a/pkg/tunnel/edgetunnel_test.go
+++ b/pkg/tunnel/edgetunnel_test.go
@@ -23,13 +23,16 @@ import (
 	"time"
 
 	clusterrouter "github.com/baidu/ote-stack/pkg/clusterrouter"
+	"github.com/baidu/ote-stack/pkg/config"
 )
 
 func newTestEdgeTunnel() *edgeTunnel {
 	return &edgeTunnel{
-		name:       "child",
-		cloudAddr:  testServer.Listener.Addr().String(),
-		listenAddr: ":8287",
+		name:               "child",
+		cloudAddr:          testServer.Listener.Addr().String(),
+		listenAddr:         ":8287",
+		conf:               &config.ClusterControllerConfig{},
+		afterConnectToHook: func() {},
 	}
 }
 func TestConnect(t *testing.T) {

--- a/pkg/tunnel/wsclient.go
+++ b/pkg/tunnel/wsclient.go
@@ -33,7 +33,7 @@ const (
 
 // WSClient is a websocket client.
 type WSClient struct {
-	// Name defines client name.
+	// Name defines uuid of the client.
 	Name string
 	// Conn defines websocket connection.
 	Conn  *websocket.Conn
@@ -49,10 +49,13 @@ type ClusterNameChecker func(*config.ClusterRegistry) bool
 type TunnelReadMessageFunc func(string, []byte) error
 
 // ClientCloseHandleFunc is a function to handle wsclient close event.
-type ClientCloseHandleFunc func(string)
+type ClientCloseHandleFunc func(*config.ClusterRegistry)
 
 // AfterConnectHook is a function to handle wsclient connection event.
 type AfterConnectHook func(*config.ClusterRegistry)
+
+// AfterConnectToHook is a function of edge tunnel to call after connection established.
+type AfterConnectToHook func()
 
 // NewWSClient returns a websocket client.
 func NewWSClient(name string, conn *websocket.Conn) *WSClient {


### PR DESCRIPTION
This pr is about 2 problems.

1. duplicated cluster name
Cluster should have an uuid so that user can identify them by the uuid. Cluster name is set when start a cluster controller instance, while maybe the name is same to a certain cluster already online. So, an uuid should be generated to assign to a cluster. The way to do that is rename the cluster every time it connect to a parent, and the new name is a combination of origin name and the unix timestamp it connects.
Even using this method, there is still probability to have two duplicated cluster name. Once in this circumstances, refuse to add the later one to router, so that there is only one can be accessed. Currently, the later one stay alive in subtree with no duplicated name, it may be disconnected and reconnect with a different name(TODO).

2. router missing
Router may be missing under certain circumstances. Assuming it is a 4 layer topology, and a cluster in layer 3 reconnect, at that time, routers of clusters under that cluster will stay in their old grandfather except migrating to their new grandfather. The pr fix problem in this situation.