### PR TITLE
rename const to follow golang naming convention and print cluster pretty

### DIFF
--- a/cmd/clustercontroller/app/app.go
+++ b/cmd/clustercontroller/app/app.go
@@ -68,7 +68,7 @@ func NewClusterControllerCommand() *cobra.Command {
 
 	cmd.AddCommand(versionCmd)
 	cmd.PersistentFlags().StringVarP(&parentCluster, "parent-cluster", "p", "", "Cloud tunnel of parent cluster, e.g., 192.168.0.2:8287")
-	cmd.PersistentFlags().StringVarP(&clusterName, "cluster-name", "n", config.ROOT_CLUSTER_NAME, "Current cluster name, must be unique")
+	cmd.PersistentFlags().StringVarP(&clusterName, "cluster-name", "n", config.RootClusterName, "Current cluster name, must be unique")
 	cmd.PersistentFlags().StringVarP(&kubeConfig, "kube-config", "k", "/root/.kube/config", "KubeConfig file path")
 	cmd.PersistentFlags().StringVarP(&tunnelListenAddr, "tunnel-listen", "l", ":8287", "Cloud tunnel listen address, e.g., 192.168.0.3:8287")
 	cmd.PersistentFlags().StringVarP(&remoteShimAddr, "remote-shim-endpoint", "r", "", "remote cluster shim unix sock address, e.g., unix://clustercontroller.sock")

--- a/cmd/k3s_cluster_shim/app/app.go
+++ b/cmd/k3s_cluster_shim/app/app.go
@@ -82,7 +82,7 @@ func Run() error {
 	signal.Notify(signals, syscall.SIGINT, syscall.SIGTERM, syscall.SIGQUIT)
 
 	s := clustershim.NewShimServer()
-	s.RegisterHandler(otev1.CLUSTER_CONTROLLER_DEST_API, handler.NewK8sHandler(k3sClient))
+	s.RegisterHandler(otev1.ClusterControllerDestAPI, handler.NewK8sHandler(k3sClient))
 
 	go func() {
 		<-signals

--- a/cmd/k8s_cluster_shim/app/app.go
+++ b/cmd/k8s_cluster_shim/app/app.go
@@ -84,9 +84,9 @@ func Run() error {
 	signal.Notify(signals, syscall.SIGINT, syscall.SIGTERM, syscall.SIGQUIT)
 
 	s := clustershim.NewShimServer()
-	s.RegisterHandler(otev1.CLUSTER_CONTROLLER_DEST_API, handler.NewK8sHandler(k8sClient))
+	s.RegisterHandler(otev1.ClusterControllerDestAPI, handler.NewK8sHandler(k8sClient))
 	// TODO directly connect helm tiller.
-	s.RegisterHandler(otev1.CLUSTER_CONTROLLER_DEST_HELM, handler.NewHTTPProxyHandler(helmConfig))
+	s.RegisterHandler(otev1.ClusterControllerDestHelm, handler.NewHTTPProxyHandler(helmConfig))
 
 	go func() {
 		<-signals

--- a/deployments/clustercontroller/clustercontroller.crd.yaml
+++ b/deployments/clustercontroller/clustercontroller.crd.yaml
@@ -13,12 +13,27 @@ spec:
     - cs
     singular: cluster
   scope: Namespaced
+  additionalPrinterColumns:
+    - name: Listen
+      type: string
+      JSONPath: .spec.listen
+    - name: Parent
+      type: string
+      JSONPath: .spec.parentName
+    - name: UserDefineName
+      type: string
+      JSONPath: .spec.name
+    - name: Age
+      type: date
+      JSONPath: .metadata.creationTimestamp
   validation:
     openAPIV3Schema:
       properties:
         spec:
           properties:
             name:
+              type: string
+            listen:
               type: string
   version: v1
 

--- a/pkg/apis/ote/v1/types.go
+++ b/pkg/apis/ote/v1/types.go
@@ -23,27 +23,27 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// CLUSTER_STATUS_REGIST describe a cluster registed status,
+// ClusterStatusRegist describe a cluster registed status,
 // should be set to Cluster.Spec.Status if a cluster've registed.
 const (
-	CLUSTER_STATUS_REGIST = "regist"
+	ClusterStatusRegist = "regist"
 )
 
-// CLUSTER_CONTROLLER_DEST_* describe the way to process ClusterController,
+// ClusterControllerDest* describe the way to process ClusterController,
 // should be set to ClusterController.Spec.Destination.
 const (
-	CLUSTER_CONTROLLER_DEST_API              = "api"      // sent to k8s apiserver
-	CLUSTER_CONTROLLER_DEST_HELM             = "helm"     // sent to helm
-	CLUSTER_CONTROLLER_DEST_REGIST_CLUSTER   = "regist"   // cluster regist
-	CLUSTER_CONTROLLER_DEST_UNREGIST_CLUSTER = "unregist" // cluster unregist
-	CLUSTER_CONTROLLER_DEST_CLUSTER_ROUTE    = "route"    // cluster route
-	CLUSTER_CONTROLLER_DEST_CLUSTER_SUBTREE  = "subtree"  // cluster subtree
+	ClusterControllerDestAPI             = "api"      // sent to k8s apiserver
+	ClusterControllerDestHelm            = "helm"     // sent to helm
+	ClusterControllerDestRegistCluster   = "regist"   // cluster regist
+	ClusterControllerDestUnregistCluster = "unregist" // cluster unregist
+	ClusterControllerDestClusterRoute    = "route"    // cluster route
+	ClusterControllerDestClusterSubtree  = "subtree"  // cluster subtree
 )
 
-// CLUSTER_NAMESPACE defines the namespace of k8s crd must be in.
+// ClusterNamespace defines the namespace of k8s crd must be in.
 // CRD out of the namespace won't be watched.
 const (
-	CLUSTER_NAMESPACE = "kube-system"
+	ClusterNamespace = "kube-system"
 )
 
 // +genclient

--- a/pkg/clusterhandler/clusterhandler_test.go
+++ b/pkg/clusterhandler/clusterhandler_test.go
@@ -46,7 +46,7 @@ func TestInit(t *testing.T) {
 	assert.Error(t, h.valid())
 
 	// test root cluster config
-	h.conf.ClusterUserDefineName = config.ROOT_CLUSTER_NAME
+	h.conf.ClusterUserDefineName = config.RootClusterName
 	assert.Error(t, h.valid())
 	h.conf.TunnelListenAddr = ":8272"
 	assert.Error(t, h.valid())
@@ -154,7 +154,7 @@ func TestStart(t *testing.T) {
 			K8sClient:             fakeK8sClient,
 			EdgeToClusterChan:     make(chan otev1.ClusterController),
 			ClusterToEdgeChan:     make(chan otev1.ClusterController),
-			ClusterUserDefineName: config.ROOT_CLUSTER_NAME,
+			ClusterUserDefineName: config.RootClusterName,
 		},
 		tunn:      fakeTunn,
 		k8sEnable: false,
@@ -204,20 +204,20 @@ func TestHandleMessageFromChild(t *testing.T) {
 
 	cc := otev1.ClusterController{}
 	// regist cluster without cluster info
-	cc.Spec.Destination = otev1.CLUSTER_CONTROLLER_DEST_REGIST_CLUSTER
+	cc.Spec.Destination = otev1.ClusterControllerDestRegistCluster
 	ccbytes, err := cc.Serialize()
 	assert.Nil(t, err)
 	err = c.handleMessageFromChild("c1", ccbytes)
 	assert.NotNil(t, err)
 	// unregist cluster without cluster info
-	cc.Spec.Destination = otev1.CLUSTER_CONTROLLER_DEST_UNREGIST_CLUSTER
+	cc.Spec.Destination = otev1.ClusterControllerDestUnregistCluster
 	ccbytes, err = cc.Serialize()
 	assert.Nil(t, err)
 	err = c.handleMessageFromChild("c1", ccbytes)
 	assert.NotNil(t, err)
 	// resp from child with no namespace and name
 	cc.Spec.ParentClusterName = c.conf.ClusterUserDefineName
-	cc.Spec.Destination = otev1.CLUSTER_CONTROLLER_DEST_API
+	cc.Spec.Destination = otev1.ClusterControllerDestAPI
 	ccbytes, err = cc.Serialize()
 	assert.Nil(t, err)
 	err = c.handleMessageFromChild("c1", ccbytes)
@@ -281,7 +281,7 @@ func (f *fakeCloudTunnel) RegistClientCloseHandler(fn tunnel.ClientCloseHandleFu
 func newFakeRootClusterHandler(t *testing.T) *clusterHandler {
 	ret := &clusterHandler{
 		conf: &config.ClusterControllerConfig{
-			ClusterUserDefineName: config.ROOT_CLUSTER_NAME,
+			ClusterUserDefineName: config.RootClusterName,
 			TunnelListenAddr:      "8272",
 			K8sClient:             oteclient.NewSimpleClientset(),
 		},

--- a/pkg/clusterrouter/router.go
+++ b/pkg/clusterrouter/router.go
@@ -161,7 +161,7 @@ func (cr *ClusterRouter) AddRoute(to, port string) error {
 		klog.Errorf(
 			"route to %s already exist from port %s, add route %s-%s failed",
 			to, oldPort, to, port)
-		return config.DUPLICATED_NAME_ERROR
+		return config.DuplicatedNameError
 	}
 	klog.Infof("route update: %v", cr.subtreeRouter)
 	return nil
@@ -286,7 +286,7 @@ func (cr *ClusterRouter) NeighborRouterMessage() *otev1.ClusterController {
 	}
 	cc := otev1.ClusterController{
 		Spec: otev1.ClusterControllerSpec{
-			Destination: otev1.CLUSTER_CONTROLLER_DEST_CLUSTER_ROUTE,
+			Destination: otev1.ClusterControllerDestClusterRoute,
 			Body:        string(cbyte),
 		},
 	}
@@ -308,7 +308,7 @@ func (cr *ClusterRouter) SubTreeMessage() *otev1.ClusterController {
 	}
 	cc := otev1.ClusterController{
 		Spec: otev1.ClusterControllerSpec{
-			Destination: otev1.CLUSTER_CONTROLLER_DEST_CLUSTER_SUBTREE,
+			Destination: otev1.ClusterControllerDestClusterSubtree,
 			Body:        string(cbyte),
 		},
 	}

--- a/pkg/clusterselector/selector.go
+++ b/pkg/clusterselector/selector.go
@@ -23,8 +23,8 @@ import (
 )
 
 const (
-	// SELECTOR_PATTERN_DELIMITER defines the delimiter of routing rules.
-	SELECTOR_PATTERN_DELIMITER = ","
+	// SelectorPatternDelimiter defines the delimiter of routing rules.
+	SelectorPatternDelimiter = ","
 )
 
 // Selector is the interface of cluster selector.
@@ -39,7 +39,7 @@ type selector struct {
 
 // NewSelector returns a new selector object with given routing rules.
 func NewSelector(s string) Selector {
-	ps := strings.Split(s, SELECTOR_PATTERN_DELIMITER)
+	ps := strings.Split(s, SelectorPatternDelimiter)
 	for i := range ps {
 		ps[i] = strings.TrimSpace(ps[i])
 	}
@@ -57,5 +57,5 @@ func (s *selector) Has(clusterName string) bool {
 
 // ClustersToSelector combines given clusters to routing rule.
 func ClustersToSelector(clusters *[]string) string {
-	return strings.Join(*clusters, SELECTOR_PATTERN_DELIMITER)
+	return strings.Join(*clusters, SelectorPatternDelimiter)
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -27,22 +27,22 @@ import (
 )
 
 const (
-	// ROOT_CLUSTER_NAME defines the cluster name of root cluster.
-	ROOT_CLUSTER_NAME = "Root"
+	// RootClusterName defines the cluster name of root cluster.
+	RootClusterName = "Root"
 
-	// CLUSTER_CONNECT_HEADER_LISTEN_ADDR defines request header to post listen address of the child.
+	// ClusterConnectHeaderListenAddr defines request header to post listen address of the child.
 	// For edge when connect to parent, set this header to address listend by the cluster,
 	// so let parent know the address of child, thus a cluster can get its neighbor from parent.
-	CLUSTER_CONNECT_HEADER_LISTEN_ADDR = "listen-addr"
-	// CLUSTER_CONNECT_HEADER_USER_DEFINE_NAME is the user-define name of the child
-	CLUSTER_CONNECT_HEADER_USER_DEFINE_NAME = "name"
+	ClusterConnectHeaderListenAddr = "listen-addr"
+	// ClusterConnectHeaderUserDefineName is the user-define name of the child
+	ClusterConnectHeaderUserDefineName = "name"
 
-	// K8S_INFORMAER_SYNC_DURATION defines k8s informer sync seconds.
-	K8S_INFORMAER_SYNC_DURATION = 10
+	// K8sInformerSyncDuration defines k8s informer sync seconds.
+	K8sInformerSyncDuration = 10
 )
 
 var (
-	DUPLICATED_NAME_ERROR = fmt.Errorf("cluster name duplicated")
+	DuplicatedNameError = fmt.Errorf("cluster name duplicated")
 )
 
 // ClusterControllerConfig contains config needed by cluster controller.
@@ -101,5 +101,5 @@ func (cr *ClusterRegistry) WrapperToClusterController(dst string) (*otev1.Cluste
 
 // IsRoot check if clusterName is a root cluster.
 func IsRoot(clusterName string) bool {
-	return ROOT_CLUSTER_NAME == clusterName
+	return RootClusterName == clusterName
 }

--- a/pkg/edgehandler/edgehandler.go
+++ b/pkg/edgehandler/edgehandler.go
@@ -147,9 +147,9 @@ func (e *edgeHandler) handleMessage(c *otev1.ClusterController) error {
 		status *otev1.ClusterControllerStatus
 	)
 
-	if c.Spec.Destination == otev1.CLUSTER_CONTROLLER_DEST_REGIST_CLUSTER ||
-		c.Spec.Destination == otev1.CLUSTER_CONTROLLER_DEST_UNREGIST_CLUSTER ||
-		c.Spec.Destination == otev1.CLUSTER_CONTROLLER_DEST_CLUSTER_ROUTE {
+	if c.Spec.Destination == otev1.ClusterControllerDestRegistCluster ||
+		c.Spec.Destination == otev1.ClusterControllerDestUnregistCluster ||
+		c.Spec.Destination == otev1.ClusterControllerDestClusterRoute {
 		return nil
 	}
 

--- a/pkg/edgehandler/edgehandler_test.go
+++ b/pkg/edgehandler/edgehandler_test.go
@@ -75,7 +75,7 @@ func newFakeShim() shimServiceClient {
 	local := &localShimClient{
 		handlers: make(map[string]handler.Handler),
 	}
-	local.handlers[otev1.CLUSTER_CONTROLLER_DEST_API] = &fakeShimHandler{}
+	local.handlers[otev1.ClusterControllerDestAPI] = &fakeShimHandler{}
 	return local
 }
 
@@ -323,7 +323,7 @@ func TestHandleMessage(t *testing.T) {
 			Data: otev1.ClusterController{
 				Spec: otev1.ClusterControllerSpec{
 					ParentClusterName: "root",
-					Destination:       otev1.CLUSTER_CONTROLLER_DEST_CLUSTER_ROUTE,
+					Destination:       otev1.ClusterControllerDestClusterRoute,
 				},
 			},
 			ExpectCode:   0,
@@ -334,7 +334,7 @@ func TestHandleMessage(t *testing.T) {
 			Data: otev1.ClusterController{
 				Spec: otev1.ClusterControllerSpec{
 					ParentClusterName: "root",
-					Destination:       otev1.CLUSTER_CONTROLLER_DEST_API,
+					Destination:       otev1.ClusterControllerDestAPI,
 				},
 			},
 			ExpectCode:   200,
@@ -345,7 +345,7 @@ func TestHandleMessage(t *testing.T) {
 			Data: otev1.ClusterController{
 				Spec: otev1.ClusterControllerSpec{
 					ParentClusterName: "root",
-					Destination:       otev1.CLUSTER_CONTROLLER_DEST_HELM,
+					Destination:       otev1.ClusterControllerDestHelm,
 				},
 			},
 			ExpectCode:   500,

--- a/pkg/edgehandler/shimclient.go
+++ b/pkg/edgehandler/shimclient.go
@@ -47,8 +47,8 @@ func newLocalShimClient(c *config.ClusterControllerConfig) shimServiceClient {
 	local := &localShimClient{
 		handlers: make(map[string]handler.Handler),
 	}
-	local.handlers[otev1.CLUSTER_CONTROLLER_DEST_API] = handler.NewK8sHandler(c.K8sClient)
-	local.handlers[otev1.CLUSTER_CONTROLLER_DEST_HELM] = handler.NewHTTPProxyHandler(c.HelmTillerAddr)
+	local.handlers[otev1.ClusterControllerDestAPI] = handler.NewK8sHandler(c.K8sClient)
+	local.handlers[otev1.ClusterControllerDestHelm] = handler.NewHTTPProxyHandler(c.HelmTillerAddr)
 	return local
 }
 

--- a/pkg/tunnel/cloudtunnel.go
+++ b/pkg/tunnel/cloudtunnel.go
@@ -164,14 +164,14 @@ func (t *cloudTunnel) accessHandler(w http.ResponseWriter, r *http.Request) {
 
 	// get cluster listen addr from header.
 	// TODO if listen addr is duplicated, refuse to connect.
-	listenAddr := r.Header.Get(config.CLUSTER_CONNECT_HEADER_LISTEN_ADDR)
+	listenAddr := r.Header.Get(config.ClusterConnectHeaderListenAddr)
 	if listenAddr == "" {
 		klog.V(1).Infof("cluster %s listenAddr is not specified, should set in header", cluster)
 		http.Error(w, "listenAddr is not specified, should set in header", http.StatusBadRequest)
 		return
 	}
 	// get name of the child
-	name := r.Header.Get(config.CLUSTER_CONNECT_HEADER_USER_DEFINE_NAME)
+	name := r.Header.Get(config.ClusterConnectHeaderUserDefineName)
 	if name == "" {
 		klog.V(1).Infof("cluster %s user-define name is not specified, should set in header", cluster)
 		http.Error(w, "user-define name is not specified, should set in header", http.StatusBadRequest)

--- a/pkg/tunnel/edgetunnel.go
+++ b/pkg/tunnel/edgetunnel.go
@@ -81,8 +81,8 @@ func (e *edgeTunnel) connect() error {
 	e.uuid = fmt.Sprintf("%s-%d", e.name, time.Now().Unix())
 	u := url.URL{Scheme: "ws", Host: e.cloudAddr, Path: accessURI + e.uuid}
 	header := http.Header{}
-	header.Add(config.CLUSTER_CONNECT_HEADER_LISTEN_ADDR, e.listenAddr)
-	header.Add(config.CLUSTER_CONNECT_HEADER_USER_DEFINE_NAME, e.name)
+	header.Add(config.ClusterConnectHeaderListenAddr, e.listenAddr)
+	header.Add(config.ClusterConnectHeaderUserDefineName, e.name)
 
 	klog.Infof("connecting to cloudtunnel %s", u.String())
 	// TODO https connection.


### PR DESCRIPTION
Two commit.
one for naming convention described here https://golang.org/doc/effective_go.html#mixed-caps
another for pretty printing cluster when using kubectl