### PR TITLE
use restclient.Verb other than write cases every method

### DIFF
--- a/pkg/clustershim/handler/k8shandler.go
+++ b/pkg/clustershim/handler/k8shandler.go
@@ -39,15 +39,9 @@ func NewK8sHandler(cl oteclient.Interface) Handler {
 func (k *k8sHandler) Do(in *pb.ShimRequest) (*pb.ShimResponse, error) {
 
 	var req *rest.Request
-	switch method := in.Method; method {
-	case http.MethodGet:
-		req = k.restclient.Get()
-	case http.MethodPost:
-		req = k.restclient.Post()
-	case http.MethodDelete:
-		req = k.restclient.Delete()
-	case http.MethodPut:
-		req = k.restclient.Put()
+	switch in.Method {
+	case http.MethodGet, http.MethodPost, http.MethodDelete, http.MethodPut:
+		req = k.restclient.Verb(in.Method)
 	case http.MethodPatch:
 		req = k.restclient.Patch(types.JSONPatchType)
 	default:


### PR DESCRIPTION
Change-Id: I4923438fccca7415b56e21225cca89085c6d4b69

restclient.Verb can access http.Method and return a request, so the cases in switch can be simplified.
![image](https://user-images.githubusercontent.com/5043930/65105448-886d4700-da07-11e9-8d48-3fb8a0eea312.png)
