### PR TITLE
change message structure between cc and shim

### DIFF
--- a/pkg/clustershim/handler/handler_test.go
+++ b/pkg/clustershim/handler/handler_test.go
@@ -1,0 +1,38 @@
+/*
+Copyright 2019 Baidu, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package handler
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/baidu/ote-stack/pkg/clustermessage"
+)
+
+func TestResponse (t *testing.T) {
+	head := &clustermessage.MessageHead{
+		Command:	clustermessage.CommandType_ControlReq,
+	}
+	resp := Response(nil, head)
+	assert.NotNil(t, resp)
+}
+
+func TestControlTaskResponse(t *testing.T) {
+	resp := ControlTaskResponse(200, "")
+	assert.NotNil(t, resp)
+}

--- a/pkg/clustershim/shimclient_test.go
+++ b/pkg/clustershim/shimclient_test.go
@@ -21,14 +21,101 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"github.com/golang/protobuf/proto"
 
 	otev1 "github.com/baidu/ote-stack/pkg/apis/ote/v1"
-	pb "github.com/baidu/ote-stack/pkg/clustershim/apis/v1"
+	"github.com/baidu/ote-stack/pkg/clustermessage"
 	"github.com/baidu/ote-stack/pkg/config"
 	oteclient "github.com/baidu/ote-stack/pkg/generated/clientset/versioned/fake"
+	"github.com/baidu/ote-stack/pkg/clustershim/handler"
 )
 
-func TestShimClientDo(t *testing.T) {
+func fakeNewlocalShimClient(c *config.ClusterControllerConfig) ShimServiceClient {
+	local := &localShimClient{
+		handlers: make(map[string]handler.Handler),
+	}
+	local.handlers["api"] = &fakeShimHandler{}
+	local.handlers[otev1.ClusterControllerDestHelm] = handler.NewHTTPProxyHandler(c.HelmTillerAddr)
+	return local
+}
+
+func getControllerTask(des string, method string, uri string, t *testing.T) []byte {
+	msg := &clustermessage.ControllerTask{
+		Destination: des,
+		Method:      method,
+		URI:         uri,
+	}
+	data, err := proto.Marshal(msg)
+	if err != nil {
+		t.Errorf("to controller task request failed: %v", err)
+		return nil
+	}
+	return data
+}
+
+func TestShimClientDoControlRequest(t *testing.T) {
+	c := &config.ClusterControllerConfig{
+		K8sClient: oteclient.NewSimpleClientset(
+			&otev1.Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "c1",
+				},
+			},
+		),
+		HelmTillerAddr: "",
+	}
+	localClient := fakeNewlocalShimClient(c).(*localShimClient)
+	assert.Nil(t, localClient.ReturnChan())
+
+	//supportable handler
+	des := "api"
+	method := "GET"
+	uri := "/apis/ote.baidu.com/v1/namespaces/default/clusters"
+	data1 := getControllerTask(des, method, uri, t)
+	msg1 := clustermessage.ClusterMessage{
+		Head: &clustermessage.MessageHead{
+			ParentClusterName:     "c1",
+			Command:               clustermessage.CommandType_ControlReq,
+			ClusterName:           "c1",
+		},
+		Body: data1,
+	}
+	resp, err := localClient.DoControlRequest(&msg1)
+	assert.Equal(t, clustermessage.CommandType_ControlResp, resp.Head.Command) // local shim client return not nil resp
+
+	// unsupportable handler
+	des = "nohandler"
+	data2 := getControllerTask(des, method, uri, t)
+	
+	msg2 := clustermessage.ClusterMessage{
+		Head: &clustermessage.MessageHead{
+			ParentClusterName:     "c1",
+			Command:               clustermessage.CommandType_ControlReq,
+			ClusterName:           "c1",
+		},
+		Body: data2,
+	}
+	resp, err = localClient.DoControlRequest(&msg2)
+	assert.NotNil(t, resp) // local shim client return not nil resp
+	assert.NotNil(t, err)
+
+	//unsupportable command
+	des = "api"
+	data3 := getControllerTask(des, method, uri, t)
+	msg3 := clustermessage.ClusterMessage{
+		Head: &clustermessage.MessageHead{
+			ParentClusterName:     "c1",
+			Command:               clustermessage.CommandType_NeighborRoute,
+			ClusterName:           "c1",
+		},
+		Body: data3,
+	}
+	resp, err = localClient.DoControlRequest(&msg3)
+	assert.Nil(t, resp) // local shim client return nil resp
+	assert.NotNil(t, err)
+}
+
+func TestShimClientDo (t *testing.T) {
 	c := &config.ClusterControllerConfig{
 		K8sClient: oteclient.NewSimpleClientset(
 			&otev1.Cluster{
@@ -41,14 +128,14 @@ func TestShimClientDo(t *testing.T) {
 	}
 	localClient := NewlocalShimClient(c)
 	assert.Nil(t, localClient.ReturnChan())
-
-	// no handler
-	in := pb.ShimRequest{
-		Destination: "nohandler",
-		Method:      "GET",
-		URL:         "/apis/ote.baidu.com/v1/namespaces/default/clusters",
+	
+	msg := clustermessage.ClusterMessage{
+		Head: &clustermessage.MessageHead{
+			Command:	clustermessage.CommandType_NeighborRoute,
+		},
 	}
-	resp, err := localClient.Do(&in)
-	assert.NotNil(t, resp) // local shim client return not nil resp
+
+	resp, err := localClient.Do(&msg)
+	assert.Nil(t, resp)
 	assert.NotNil(t, err)
 }

--- a/pkg/clustershim/shimserver_test.go
+++ b/pkg/clustershim/shimserver_test.go
@@ -19,65 +19,128 @@ package clustershim
 import (
 	"testing"
 	"time"
+	"fmt"
 
-	pb "github.com/baidu/ote-stack/pkg/clustershim/apis/v1"
+	"github.com/golang/protobuf/proto"
+	"github.com/stretchr/testify/assert"
+	
+	"github.com/baidu/ote-stack/pkg/clustermessage"
 )
 
 type fakeShimHandler struct{}
 
-func (f *fakeShimHandler) Do(in *pb.ShimRequest) (*pb.ShimResponse, error) {
-	resp := &pb.ShimResponse{
-		Timestamp:  time.Now().Unix(),
-		StatusCode: 200,
-		Body:       "",
-	}
-	return resp, nil
+func (f *fakeShimHandler) Do(in *clustermessage.ClusterMessage) (*clustermessage.ClusterMessage, error) {
+	switch in.Head.Command {
+	case clustermessage.CommandType_ControlReq:
+		resp := &clustermessage.ControllerTaskResponse{
+			Timestamp:  time.Now().Unix(),
+			StatusCode: 200,
+			Body:       []byte(""),
+		}
+	
+		data, err := proto.Marshal(resp)
+		if err != nil {
+			fmt.Errorf("shim resp to controller task resp failed: %v", err)
+			return &clustermessage.ClusterMessage{Head: in.Head,}, nil
+		}
+	
+		msg := &clustermessage.ClusterMessage{
+			Head: in.Head,
+			Body: data,
+		}
+		return msg, nil
+	default:
+		return nil, fmt.Errorf("command %s is not supported by ShimClient", in.Head.Command.String())
+	} 
 }
 
 func TestDo(t *testing.T) {
 	server := NewShimServer()
 	server.RegisterHandler("api", &fakeShimHandler{})
+
+	//unsupportable command
+	data1 := getControllerTask("api", "", "", t)
+	
+	msg := &clustermessage.ClusterMessage{
+		Head: &clustermessage.MessageHead{
+			Command: clustermessage.CommandType_NeighborRoute,
+		}, 
+		Body: data1,
+	}
+
+	resp, err := server.Do(msg)
+	assert.Nil(t, resp)
+	assert.NotNil(t, err)
+}
+
+func TestDoControlRequest(t *testing.T) {
+	server := NewShimServer()
+	server.RegisterHandler("api", &fakeShimHandler{})
+
+	data1 := getControllerTask("api", "", "", t)
+	
 	successcase := []struct {
 		Name       string
-		Request    *pb.ShimRequest
+		Request    *clustermessage.ClusterMessage
 		ExpectCode int32
 	}{
 		{
 			Name: "success",
-			Request: &pb.ShimRequest{
-				Destination: "api",
+			Request: &clustermessage.ClusterMessage{
+				Head: &clustermessage.MessageHead{
+					Command: clustermessage.CommandType_ControlReq,
+				}, 
+				Body: data1,
 			},
 			ExpectCode: 200,
 		},
 	}
 
 	for _, sc := range successcase {
-		resp, err := server.Do(sc.Request)
-		if err != nil {
-			t.Errorf("[%q] unexpected error %v", sc.Name, err)
-		}
+		resp, err := server.DoControlRequest(sc.Request)
+		assert.Nil(t, err)
 
-		if resp.StatusCode != sc.ExpectCode {
-			t.Errorf("[%q] expected %v, got %v", sc.Name, sc.ExpectCode, resp.StatusCode)
+		task := &clustermessage.ControllerTaskResponse{}
+		err = proto.Unmarshal([]byte(resp.Body), task)
+		if err != nil {
+			t.Errorf("unmarshal controller task response failed: %v", err)
 		}
+		assert.Equal(t, sc.ExpectCode, task.StatusCode)
 	}
+
+	data2 := getControllerTask("test", "", "", t)
 
 	errorcase := []struct {
 		Name    string
-		Request *pb.ShimRequest
+		Request *clustermessage.ClusterMessage
 	}{
 		{
 			Name: "no handler",
-			Request: &pb.ShimRequest{
-				Destination: "test",
+			Request: &clustermessage.ClusterMessage{
+				Head: &clustermessage.MessageHead{
+					Command: clustermessage.CommandType_ControlReq,
+				},
+				Body: data2,
+			},
+		},
+		{
+			Name: "no command",
+			Request: &clustermessage.ClusterMessage{
+				Head: &clustermessage.MessageHead{
+					Command: clustermessage.CommandType_NeighborRoute,
+				},
+				Body: data1,
 			},
 		},
 	}
 
 	for _, ec := range errorcase {
-		_, err := server.Do(ec.Request)
-		if err == nil {
-			t.Errorf("[%q] expected error", ec.Name)
+		resp, err := server.DoControlRequest(ec.Request)
+		assert.NotNil(t, err)
+		if ec.Name == "no command" {
+			assert.Nil(t, resp)
+		} else {
+			assert.NotNil(t, resp)
 		}
 	}
 }


### PR DESCRIPTION
Change-Id: If03da5ca161d576aabd5b9e88e909652c559e9dd

change the message structure to ClusterMessage between cc and shim, and it can keep the message structure between cc and shim consistent.